### PR TITLE
Add news script editor

### DIFF
--- a/NewsAI.Editor.Client/package-lock.json
+++ b/NewsAI.Editor.Client/package-lock.json
@@ -8,7 +8,9 @@
       "name": "vite-react-typescript-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
         "autoprefixer": "^10.4.21",
+        "monaco-editor": "^0.52.2",
         "postcss": "^8.5.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1052,6 +1054,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3871,6 +3896,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4558,6 +4589,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",

--- a/NewsAI.Editor.Client/package.json
+++ b/NewsAI.Editor.Client/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
     "autoprefixer": "^10.4.21",
+    "monaco-editor": "^0.52.2",
     "postcss": "^8.5.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/NewsAI.Editor.Client/src/components/EditorLayout.tsx
+++ b/NewsAI.Editor.Client/src/components/EditorLayout.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import ScriptEditor from './ScriptEditor';
 
 interface Props {
   onLogout?: () => void;
@@ -28,7 +29,9 @@ export default function EditorLayout({ onLogout }: Props) {
       </header>
 
       <div className="grid grid-cols-[30%_1fr_30%] h-full relative">
-        <div className="border-r border-gray-300 overflow-auto p-2">Script Editor</div>
+        <div className="border-r border-gray-300 overflow-auto p-2">
+          <ScriptEditor />
+        </div>
         <div className="flex flex-col items-center justify-center border-r border-gray-300 overflow-auto p-2">Video Preview</div>
         <div className="overflow-auto p-2">Timeline</div>
         <div className="absolute top-0 left-[30%] w-1 bg-gray-200 cursor-col-resize" />

--- a/NewsAI.Editor.Client/src/components/ScriptEditor.tsx
+++ b/NewsAI.Editor.Client/src/components/ScriptEditor.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from 'react';
+import Editor, { loader } from '@monaco-editor/react';
+import type { Monaco } from '@monaco-editor/react';
+
+loader.config({ paths: { vs: '/node_modules/monaco-editor/min/vs' } });
+
+const SAMPLE_SCRIPT = `[VIDEO: Shots of littered beaches, volunteers cleaning up]
+EMMA (VO): Sydney's iconic beaches are under threat as plastic waste continues to wash ashore...
+[SOUND BITE – Environmental Scientist]: "We're seeing a dramatic rise in microplastics..."`;
+
+export default function ScriptEditor() {
+  const monacoRef = useRef<Monaco | null>(null);
+  const [value, setValue] = useState(SAMPLE_SCRIPT);
+  const wordCount = value.split(/\s+/).filter(Boolean).length;
+  const duration = Math.ceil(wordCount / 150 * 60); // seconds
+
+  useEffect(() => {
+    if (monacoRef.current) {
+      const monaco = monacoRef.current;
+      if (!monaco.languages.getEncodedLanguageId('news-script')) {
+        monaco.languages.register({ id: 'news-script' });
+        monaco.languages.setMonarchTokensProvider('news-script', {
+          tokenizer: {
+            root: [
+              [/\[VIDEO:[^\]]*\]/, 'videoTag'],
+              [/\[SOUND BITE[^\]]*\]/, 'soundbiteTag'],
+              [/\(VO\)/, 'voTag'],
+              [/^[A-Z]+(?=\s+\()/, 'speaker'],
+            ]
+          }
+        });
+        monaco.editor.defineTheme('news-theme', {
+          base: 'vs',
+          inherit: true,
+          rules: [
+            { token: 'videoTag', foreground: '0000ff' },
+            { token: 'soundbiteTag', foreground: 'ff8800' },
+            { token: 'voTag', foreground: '008800' },
+            { token: 'speaker', fontStyle: 'bold' },
+          ],
+          colors: {}
+        });
+      }
+    }
+  }, []);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center justify-between bg-gray-100 p-2 border-b">
+        <div>Words: {wordCount}</div>
+        <div>Est. Duration: {duration}s</div>
+        <select className="border p-1">
+          <option>Templates</option>
+        </select>
+        <button className="px-2 py-1 bg-blue-500 text-white rounded">AI Assist</button>
+      </div>
+      <Editor
+        height="100%"
+        defaultLanguage="news-script"
+        defaultValue={SAMPLE_SCRIPT}
+        theme="news-theme"
+        onMount={(_editor, monaco) => { monacoRef.current = monaco; }}
+        onChange={(val) => setValue(val || '')}
+        options={{ minimap: { enabled: false } }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Monaco editor with custom syntax for news scripts
- show word count and duration toolbar
- integrate new script editor into layout
- add Monaco packages

## Testing
- `npm run lint`
- `npm run build`
- `dotnet test NewsAI.Editor.Api` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68789c295cb88323948c99affa3092bb