### PR TITLE
Add Edit Story button UI

### DIFF
--- a/NewsAI.Editor.Client/src/components/EditStoryButton.tsx
+++ b/NewsAI.Editor.Client/src/components/EditStoryButton.tsx
@@ -1,0 +1,31 @@
+
+interface Props {
+  status: 'disabled' | 'ready' | 'processing' | 'complete';
+  onClick: () => void;
+  progress?: number;
+}
+
+export default function EditStoryButton({ status, onClick, progress = 0 }: Props) {
+  const pulse = status === 'ready' ? 'animate-pulse' : '';
+  const disabled = status === 'disabled' || status === 'processing';
+  const text = status === 'complete' ? 'Edit Complete \u2713' : 'EDIT STORY';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={`relative w-[300px] h-[80px] rounded text-white font-bold flex flex-col items-center justify-center bg-gradient-to-r from-blue-500 to-purple-500 ${pulse} ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+    >
+      <span className="text-2xl">🤖 {text}</span>
+      {status !== 'complete' && (
+        <span className="text-xs">AI will create your rough cut</span>
+      )}
+      {status === 'processing' && (
+        <div className="absolute bottom-0 left-0 w-full h-2 bg-gray-700">
+          <div className="bg-green-400 h-2" style={{ width: `${progress}%` }} />
+        </div>
+      )}
+    </button>
+  );
+}

--- a/NewsAI.Editor.Client/src/components/EditorLayout.tsx
+++ b/NewsAI.Editor.Client/src/components/EditorLayout.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
-import ScriptEditor from './ScriptEditor';
-import MediaBin from './MediaBin';
+import { useState, useEffect } from 'react';
+import ScriptEditor, { SAMPLE_SCRIPT } from './ScriptEditor';
+import MediaBin, { type MediaFile } from './MediaBin';
 import VideoPreview from './VideoPreview';
+import EditStoryButton from './EditStoryButton';
 
 interface Props {
   onLogout?: () => void;
@@ -9,6 +10,34 @@ interface Props {
 
 export default function EditorLayout({ onLogout }: Props) {
   const [showMediaBin, setShowMediaBin] = useState(true);
+  const [script, setScript] = useState(SAMPLE_SCRIPT);
+  const [mediaFiles, setMediaFiles] = useState<MediaFile[]>([]);
+  const [editStatus, setEditStatus] = useState<'disabled' | 'ready' | 'processing' | 'complete'>('disabled');
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    if (script.trim() && mediaFiles.length > 0) {
+      setEditStatus((s) => (s === 'complete' ? 'complete' : 'ready'));
+    } else {
+      setEditStatus('disabled');
+    }
+  }, [script, mediaFiles]);
+
+  const handleEdit = () => {
+    if (editStatus !== 'ready') return;
+    setEditStatus('processing');
+    setProgress(0);
+    const interval = setInterval(() => {
+      setProgress((p) => {
+        const next = Math.min(p + 10, 100);
+        if (next >= 100) {
+          clearInterval(interval);
+          setEditStatus('complete');
+        }
+        return next;
+      });
+    }, 300);
+  };
 
   return (
     <div className="grid grid-rows-[auto_1fr_auto] h-screen">
@@ -32,19 +61,22 @@ export default function EditorLayout({ onLogout }: Props) {
 
       <div className="grid grid-cols-[30%_1fr_30%] h-full relative">
         <div className="border-r border-gray-300 overflow-auto p-2">
-          <ScriptEditor />
+          <ScriptEditor value={script} onChange={setScript} />
         </div>
         <div className="flex flex-col items-center justify-center border-r border-gray-300 overflow-auto p-2">
           <VideoPreview />
         </div>
-        <div className="overflow-auto p-2">Timeline</div>
+        <div className="overflow-auto p-2 flex flex-col items-center">
+          <EditStoryButton status={editStatus} onClick={handleEdit} progress={progress} />
+          <div className="mt-4">Timeline</div>
+        </div>
         <div className="absolute top-0 left-[30%] w-1 bg-gray-200 cursor-col-resize" />
         <div className="absolute top-0 left-[70%] w-1 bg-gray-200 cursor-col-resize" />
       </div>
 
       {showMediaBin && (
         <div className="h-[200px] border-t border-gray-300 bg-gray-50 p-2">
-          <MediaBin />
+          <MediaBin onMediaChange={setMediaFiles} />
         </div>
       )}
       <button

--- a/NewsAI.Editor.Client/src/components/MediaBin.tsx
+++ b/NewsAI.Editor.Client/src/components/MediaBin.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { v4 as uuidv4 } from 'uuid';
 
-interface MediaFile {
+export interface MediaFile {
   id: string;
   url: string;
   name: string;
@@ -18,7 +18,11 @@ interface UploadingFile {
 
 const fakeDuration = () => Math.round(Math.random() * 200) + 30;
 
-export default function MediaBin() {
+interface Props {
+  onMediaChange?: (files: MediaFile[]) => void;
+}
+
+export default function MediaBin({ onMediaChange }: Props) {
   const [files, setFiles] = useState<MediaFile[]>([]);
   const [uploading, setUploading] = useState<UploadingFile[]>([]);
   const [search, setSearch] = useState('');
@@ -75,6 +79,10 @@ export default function MediaBin() {
     if (search && !f.name.toLowerCase().includes(search.toLowerCase())) return false;
     return true;
   });
+
+  useEffect(() => {
+    onMediaChange?.(files);
+  }, [files, onMediaChange]);
 
   return (
     <div className="h-full flex flex-col" {...getRootProps()}>

--- a/NewsAI.Editor.Client/src/components/ScriptEditor.tsx
+++ b/NewsAI.Editor.Client/src/components/ScriptEditor.tsx
@@ -1,16 +1,20 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import Editor, { loader } from '@monaco-editor/react';
 import type { Monaco } from '@monaco-editor/react';
 
 loader.config({ paths: { vs: '/node_modules/monaco-editor/min/vs' } });
 
-const SAMPLE_SCRIPT = `[VIDEO: Shots of littered beaches, volunteers cleaning up]
+export const SAMPLE_SCRIPT = `[VIDEO: Shots of littered beaches, volunteers cleaning up]
 EMMA (VO): Sydney's iconic beaches are under threat as plastic waste continues to wash ashore...
 [SOUND BITE – Environmental Scientist]: "We're seeing a dramatic rise in microplastics..."`;
 
-export default function ScriptEditor() {
+interface Props {
+  value: string;
+  onChange: (val: string) => void;
+}
+
+export default function ScriptEditor({ value, onChange }: Props) {
   const monacoRef = useRef<Monaco | null>(null);
-  const [value, setValue] = useState(SAMPLE_SCRIPT);
   const wordCount = value.split(/\s+/).filter(Boolean).length;
   const duration = Math.ceil(wordCount / 150 * 60); // seconds
 
@@ -57,10 +61,10 @@ export default function ScriptEditor() {
       <Editor
         height="100%"
         defaultLanguage="news-script"
-        defaultValue={SAMPLE_SCRIPT}
+        value={value}
         theme="news-theme"
         onMount={(_editor, monaco) => { monacoRef.current = monaco; }}
-        onChange={(val) => setValue(val || '')}
+        onChange={(val) => onChange(val || '')}
         options={{ minimap: { enabled: false } }}
       />
     </div>


### PR DESCRIPTION
## Summary
- implement `EditStoryButton` component with gradient and progress bar
- update `EditorLayout` to manage edit states and display the button
- make `ScriptEditor` and `MediaBin` communicate with `EditorLayout`

## Testing
- `npm install`
- `npm run build`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878b5eb9ba88323ab9e68740f0c64c8