### PR TITLE
Add processing modal for editing

### DIFF
--- a/NewsAI.Editor.Client/src/components/EditStoryButton.tsx
+++ b/NewsAI.Editor.Client/src/components/EditStoryButton.tsx
@@ -2,10 +2,9 @@
 interface Props {
   status: 'disabled' | 'ready' | 'processing' | 'complete';
   onClick: () => void;
-  progress?: number;
 }
 
-export default function EditStoryButton({ status, onClick, progress = 0 }: Props) {
+export default function EditStoryButton({ status, onClick }: Props) {
   const pulse = status === 'ready' ? 'animate-pulse' : '';
   const disabled = status === 'disabled' || status === 'processing';
   const text = status === 'complete' ? 'Edit Complete \u2713' : 'EDIT STORY';
@@ -20,11 +19,6 @@ export default function EditStoryButton({ status, onClick, progress = 0 }: Props
       <span className="text-2xl">🤖 {text}</span>
       {status !== 'complete' && (
         <span className="text-xs">AI will create your rough cut</span>
-      )}
-      {status === 'processing' && (
-        <div className="absolute bottom-0 left-0 w-full h-2 bg-gray-700">
-          <div className="bg-green-400 h-2" style={{ width: `${progress}%` }} />
-        </div>
       )}
     </button>
   );

--- a/NewsAI.Editor.Client/src/components/EditorLayout.tsx
+++ b/NewsAI.Editor.Client/src/components/EditorLayout.tsx
@@ -3,6 +3,7 @@ import ScriptEditor, { SAMPLE_SCRIPT } from './ScriptEditor';
 import MediaBin, { type MediaFile } from './MediaBin';
 import VideoPreview from './VideoPreview';
 import EditStoryButton from './EditStoryButton';
+import ProcessingModal from './ProcessingModal';
 
 interface Props {
   onLogout?: () => void;
@@ -13,7 +14,7 @@ export default function EditorLayout({ onLogout }: Props) {
   const [script, setScript] = useState(SAMPLE_SCRIPT);
   const [mediaFiles, setMediaFiles] = useState<MediaFile[]>([]);
   const [editStatus, setEditStatus] = useState<'disabled' | 'ready' | 'processing' | 'complete'>('disabled');
-  const [progress, setProgress] = useState(0);
+  const [showProcessing, setShowProcessing] = useState(false);
 
   useEffect(() => {
     if (script.trim() && mediaFiles.length > 0) {
@@ -26,17 +27,7 @@ export default function EditorLayout({ onLogout }: Props) {
   const handleEdit = () => {
     if (editStatus !== 'ready') return;
     setEditStatus('processing');
-    setProgress(0);
-    const interval = setInterval(() => {
-      setProgress((p) => {
-        const next = Math.min(p + 10, 100);
-        if (next >= 100) {
-          clearInterval(interval);
-          setEditStatus('complete');
-        }
-        return next;
-      });
-    }, 300);
+    setShowProcessing(true);
   };
 
   return (
@@ -67,7 +58,7 @@ export default function EditorLayout({ onLogout }: Props) {
           <VideoPreview />
         </div>
         <div className="overflow-auto p-2 flex flex-col items-center">
-          <EditStoryButton status={editStatus} onClick={handleEdit} progress={progress} />
+          <EditStoryButton status={editStatus} onClick={handleEdit} />
           <div className="mt-4">Timeline</div>
         </div>
         <div className="absolute top-0 left-[30%] w-1 bg-gray-200 cursor-col-resize" />
@@ -85,6 +76,17 @@ export default function EditorLayout({ onLogout }: Props) {
       >
         {showMediaBin ? 'Hide Bin' : 'Show Bin'}
       </button>
+      <ProcessingModal
+        open={showProcessing}
+        onCancel={() => {
+          setShowProcessing(false);
+          setEditStatus('ready');
+        }}
+        onComplete={() => {
+          setShowProcessing(false);
+          setEditStatus('complete');
+        }}
+      />
     </div>
   );
 }

--- a/NewsAI.Editor.Client/src/components/ProcessingModal.tsx
+++ b/NewsAI.Editor.Client/src/components/ProcessingModal.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+
+const STEPS = [
+  'Analyzing script',
+  'Identifying required shots',
+  'Matching interviews',
+  'Creating timeline',
+  'Adjusting audio',
+];
+
+interface Props {
+  open: boolean;
+  onCancel: () => void;
+  onComplete: () => void;
+}
+
+export default function ProcessingModal({ open, onCancel, onComplete }: Props) {
+  const [progress, setProgress] = useState(0);
+  const [currentStep, setCurrentStep] = useState(0);
+
+  useEffect(() => {
+    if (!open) return;
+
+    setProgress(0);
+    setCurrentStep(0);
+
+    const durations = STEPS.map(() => 2000 + Math.random() * 1000);
+    let step = 0;
+    let interval: number;
+
+    const runStep = () => {
+      const start = Date.now();
+      const duration = durations[step];
+      interval = setInterval(() => {
+        const elapsed = Date.now() - start;
+        const part = Math.min(elapsed / duration, 1);
+        setCurrentStep(step);
+        setProgress(((step + part) / STEPS.length) * 100);
+        if (part >= 1) {
+          clearInterval(interval);
+          step += 1;
+          if (step < STEPS.length) {
+            runStep();
+          } else {
+            setCurrentStep(STEPS.length - 1);
+            setProgress(100);
+            onComplete();
+          }
+        }
+      }, 100);
+    };
+
+    runStep();
+    return () => clearInterval(interval);
+  }, [open, onComplete]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="bg-white w-[600px] h-[400px] rounded shadow-lg p-6 flex flex-col">
+        <div className="text-lg font-bold mb-4 text-center">Processing</div>
+        <div className="flex items-center justify-center mb-2 h-6">
+          <span className="mr-2">{STEPS[currentStep]}</span>
+          <span className="animate-spin rounded-full h-4 w-4 border-2 border-gray-400 border-t-transparent" />
+        </div>
+        <div className="w-full bg-gray-200 h-3 rounded mb-4">
+          <div className="bg-blue-500 h-3 rounded" style={{ width: `${progress}%` }} />
+        </div>
+        <ul className="flex-1 space-y-1">
+          {STEPS.map((s, i) => (
+            <li key={s} className="flex items-center gap-2">
+              {i < currentStep ? (
+                <span className="text-green-600">&#10003;</span>
+              ) : i === currentStep ? (
+                <span className="text-gray-600">&#x27f3;</span>
+              ) : (
+                <span className="text-gray-400">&#9675;</span>
+              )}
+              <span>{s}</span>
+            </li>
+          ))}
+        </ul>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="mt-4 self-end px-4 py-2 bg-red-500 text-white rounded"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add ProcessingModal with step simulation
- integrate ProcessingModal into EditorLayout
- simplify EditStoryButton UI

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6878b76edc148323b9b3d7dad7fac6a4